### PR TITLE
[Fix] Migration generator

### DIFF
--- a/lib/generators/punching_bag/punching_bag_generator.rb
+++ b/lib/generators/punching_bag/punching_bag_generator.rb
@@ -6,12 +6,8 @@ class PunchingBagGenerator < Rails::Generators::Base
   source_root File.join(File.dirname(__FILE__), 'templates')
 
   def self.next_migration_number(dirname)
-    sleep 1
-    if ActiveRecord::Base.timestamped_migrations
-      Time.now.utc.strftime("%Y%m%d%H%M%S")
-    else
-      "%.3d" % (current_migration_number(dirname) + 1)
-    end
+    next_migration_number = current_migration_number(dirname) + 1
+    ActiveRecord::Migration.next_migration_number(next_migration_number)
   end
 
   def create_migration_file


### PR DESCRIPTION
ActiveRecord::Base.timestamped_migrations is deprecated.